### PR TITLE
Fix priority not updated in user task update

### DIFF
--- a/task-backend/src/repository/task_repository.rs
+++ b/task-backend/src/repository/task_repository.rs
@@ -452,6 +452,11 @@ impl TaskRepository {
             }
         }
 
+        if let Some(priority_val) = payload.priority {
+            active_model.priority = Set(priority_val);
+            changed = true;
+        }
+
         if payload.due_date.is_some() {
             active_model.due_date = Set(payload.due_date);
             changed = true;


### PR DESCRIPTION
## Summary
- allow `update_task_for_user` to update priority field in task repository

## Testing
- `cargo test` *(fails: no matching package named `async-stripe` found)*

------
https://chatgpt.com/codex/tasks/task_e_68826b79ea448323890104fd1d10977e